### PR TITLE
Fix Next widget navigation logic in focus mode

### DIFF
--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -263,7 +263,10 @@ function navigateMessages(direction) {
     const messages = Array.from(document.querySelectorAll('.message'));
     if (messages.length === 0) return;
 
-    const containerTop = els.scrollContainer.scrollTop;
+    const sc = els.scrollContainer;
+    const containerTop = sc.scrollTop;
+    const isAtBottom = Math.abs(sc.scrollHeight - sc.clientHeight - sc.scrollTop) < 5;
+
     let currentIndex = -1;
     for (let i = 0; i < messages.length; i++) {
         if (messages[i].offsetTop >= containerTop - 20) {
@@ -272,6 +275,10 @@ function navigateMessages(direction) {
         }
     }
     if (currentIndex === -1) currentIndex = messages.length - 1;
+
+    if (direction === 1 && isAtBottom) {
+        currentIndex = messages.length - 1;
+    }
 
     let nextIndex = currentIndex + direction;
 


### PR DESCRIPTION
This PR fixes an issue where the Next navigation button would fail to advance to the next conversation turn (focus page) when using Focus Mode.

Previously, the logic relied solely on the scroll offset to determine the current message index. If the content fit entirely within the viewport or the user was already scrolled to the bottom, the calculation would resolve to the last message of the current turn, but simply scroll to it rather than triggering the logic to load the next prompt index.

The fix adds a check for the scroll container's bottom position. If the user is at the bottom and clicks Next, the system now forces the transition to the next conversation turn.

Closes #35