### PR TITLE
Fix paste interception and enhance raw ID support

### DIFF
--- a/src/css/components.css
+++ b/src/css/components.css
@@ -21,6 +21,13 @@
 .btn-primary:hover {
     opacity: 0.9;
     transform: translateY(-1px);
+
+    &:hover::after {
+        content: '';
+        position: absolute;
+        inset: 0;
+        bottom: -3px;
+    }
 }
 
 .btn-primary.btn-centered:hover {

--- a/src/css/layout.css
+++ b/src/css/layout.css
@@ -28,6 +28,7 @@
     width: 32px;
     height: 32px;
     object-fit: contain;
+    cursor: pointer;
 }
 
 .brand-text h1 {

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -846,7 +846,13 @@ function setupEventListeners() {
     });
 
     document.addEventListener('click', (e) => {
-        if (!exportWidgetPopover.contains(e.target) && e.target !== exportWidgetBtn) {
+        // Link Popover click outside
+        if (!linkPopover.contains(e.target) && e.target !== linkBtn && !linkBtn.contains(e.target)) {
+            linkPopover.classList.add('hidden');
+        }
+
+        // Export Popover click outside
+        if (!exportWidgetPopover.contains(e.target) && e.target !== exportWidgetBtn && !exportWidgetBtn.contains(e.target)) {
             exportWidgetPopover.classList.add('hidden');
         }
     });

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -176,15 +176,19 @@ function loadFileFromRecord(record, startIndex = null) {
     UI.hideLoading();
 }
 
-function loadFromDrive(id, startIndex = null) {
-    UI.showLoading();
-    updateUrl(id);
-    state.currentFileId = id;
+function loadFromDrive(id, startIndex = null, isSilent = false) {
+    if (!isSilent) UI.showLoading();
+
     fetchDriveFile(id, {
         onSuccess: (text) => {
+            if (isSilent) UI.showLoading(); // Show it now that we know it's valid
+            updateUrl(id);
+            state.currentFileId = id;
             handleText(text, `Drive File (${id})`, id, startIndex);
         },
         onError: (err) => {
+            if (isSilent) return; // Fail silently for raw ID pastes that don't work
+
             UI.hideLoading();
             if (err.message === "Private File / HTML content") {
                 UI.showError("Access Denied", "This file appears to be private.", true, () => loadFromDrive(id, startIndex), id);
@@ -687,6 +691,9 @@ function setupEventListeners() {
 
     // Paste
     window.addEventListener('paste', async (e) => {
+        const isInput = e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA' || e.target.isContentEditable;
+        if (isInput) return;
+
         if (!state.parsedData && e.clipboardData) {
             e.preventDefault();
             const text = e.clipboardData.getData('text');
@@ -705,10 +712,11 @@ function setupEventListeners() {
 
     function handlePaste(text) {
         const trimmed = text.trim();
-        if (trimmed.includes('aistudio.google.com') || trimmed.includes('/prompts/') || trimmed.includes('/app/prompts/') || trimmed.includes('/file/d/')) {
-            const id = parseDriveLink(trimmed);
-            if(id) loadFromDrive(id);
-            else UI.showError("Link Error", "Could not parse ID from link.");
+        const id = parseDriveLink(trimmed);
+
+        if (id) {
+            // It's a link or a raw ID
+            loadFromDrive(id, null, trimmed === id); // third param is 'isSilent'
         } else {
             updateUrl(null);
             handleText(trimmed, "Pasted content", null);

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -176,7 +176,7 @@ function loadFileFromRecord(record, startIndex = null) {
     UI.hideLoading();
 }
 
-function loadFromDrive(id, startIndex = null, isSilent = false) {
+function loadFromDrive(id, startIndex = null, isSilent = false, fallbackText = null) {
     if (!isSilent) UI.showLoading();
 
     fetchDriveFile(id, {
@@ -187,7 +187,14 @@ function loadFromDrive(id, startIndex = null, isSilent = false) {
             handleText(text, `Drive File (${id})`, id, startIndex);
         },
         onError: (err) => {
-            if (isSilent) return; // Fail silently for raw ID pastes that don't work
+            if (isSilent) {
+                // If it was a silent attempt and we have fallback text, treat as regular text
+                if (fallbackText) {
+                    updateUrl(null);
+                    handleText(fallbackText, "Pasted content", null);
+                }
+                return;
+            }
 
             UI.hideLoading();
             if (err.message === "Private File / HTML content") {
@@ -681,9 +688,13 @@ function setupEventListeners() {
             const text = e.dataTransfer.getData('text');
             if (text) {
                 const trimmed = text.trim();
-                if (trimmed.includes('aistudio.google.com') || trimmed.includes('/prompts/') || trimmed.includes('/app/prompts/') || trimmed.includes('/file/d/')) {
-                    const id = parseDriveLink(trimmed);
-                    if (id) loadFromDrive(id);
+                const id = parseDriveLink(trimmed);
+                if (id) {
+                    const isSilent = (trimmed === id);
+                    loadFromDrive(id, null, isSilent, isSilent ? trimmed : null);
+                } else {
+                    updateUrl(null);
+                    handleText(trimmed, "Dropped content", null);
                 }
             }
         }
@@ -716,7 +727,8 @@ function setupEventListeners() {
 
         if (id) {
             // It's a link or a raw ID
-            loadFromDrive(id, null, trimmed === id); // third param is 'isSilent'
+            const isSilent = (trimmed === id);
+            loadFromDrive(id, null, isSilent, isSilent ? trimmed : null);
         } else {
             updateUrl(null);
             handleText(trimmed, "Pasted content", null);
@@ -949,6 +961,13 @@ function setupEventListeners() {
         cancelFetch();
         window.location.reload();
     });
+
+    const logo = document.querySelector('#sidebar .logo-img');
+    if (logo) {
+        logo.addEventListener('click', () => {
+            resetAppState();
+        });
+    }
 }
 
 function setupThemeLogic() {

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -643,6 +643,12 @@ function setupEventListeners() {
     };
 
     window.addEventListener('dragover', (e) => {
+        const isInput = e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA' || e.target.isContentEditable;
+        if (isInput) {
+            document.body.style.opacity = '1';
+            return;
+        }
+
         const isFileLoaded = !!state.parsedData;
         const inLoadArea = isDropInLoadArea(e);
         const loadGroup = document.getElementById('loadGroup');
@@ -668,6 +674,14 @@ function setupEventListeners() {
     });
 
     window.addEventListener('drop', (e) => {
+        const isInput = e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA' || e.target.isContentEditable;
+        if (isInput) {
+            document.body.style.opacity = '1';
+            const loadGroup = document.getElementById('loadGroup');
+            if (loadGroup) loadGroup.classList.remove('drag-active');
+            return;
+        }
+
         const isFileLoaded = !!state.parsedData;
         const inLoadArea = isDropInLoadArea(e);
         const loadGroup = document.getElementById('loadGroup');


### PR DESCRIPTION
This change fixes a bug where the global "paste anywhere" listener would steal paste events from input fields (like the Link Importer), causing "Invalid JSON" errors. It also implements a feature to allow pasting raw File IDs anywhere when no file is loaded, which will silently attempt to load the file from Google Drive.

---
*PR created automatically by Jules for task [9044405019438807843](https://jules.google.com/task/9044405019438807843) started by @TimChinye*